### PR TITLE
[Fix/database] postgresql docker 포트번호 변경

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: postgres
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
 


### PR DESCRIPTION
## 개요
### 문제 상황
로컬에 설치된 pgAdmin과 Docker로 실행한 PostgreSQL이 같은 포트 번호를 사용하면서 충돌이 발생했습니다. 그러나 에러 메시지에는 `FATAL: role "postgres" does not exist`라고 표시되어 있어, 충돌 원인을 파악하는 데 시간이 걸렸습니다.

이러한 에러 메시지가 표시된 이유는 Docker로 실행한 데이터베이스가 아닌, pgAdmin에 띄운 데이터베이스에 접속을 시도했기 때문입니다.

### 해결 과정
`lsof -i` 명령어로 현재 사용 중인 포트 번호들을 확인했을 때, `com.docke 37232 mac 128u IPv6 0x7286829e330da8b3 0t0 TCP :dttl (LISTEN)` 과 같은 dttl 에러가 발생한 것을 확인할 수 있었습니다.

### 해결 방법
포트 번호가 충돌한 것을 확인하고, Docker로 실행한 PostgreSQL의 포트 번호를 변경하여 문제를 해결했습니다.

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).